### PR TITLE
Add SetTransport method

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,6 +37,10 @@ func (c *Client) SetHeader(key, value string) {
 	c.headers.Add(key, value)
 }
 
+func (c *Client) SetTransport(transport http.RoundTripper) {
+	c.c.Transport = transport
+}
+
 func (c *Client) Connect() error {
 	rs, err := c.options("/")
 	if err == nil {


### PR DESCRIPTION
Hi,

I am trying to access WebDAV servers that authenticate users based on client certificates. For this, I need to set up an http.Transport with its TLSClientConfig field properly initialised.

This call would allow to override the default transport, which should also allow to override proxy settings, timeouts and the like.

Regards.