### PR TITLE
Handle error response when reading a file.

### DIFF
--- a/client.go
+++ b/client.go
@@ -261,7 +261,12 @@ func (c *Client) ReadStream(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, newPathErrorErr("ReadStream", path, err)
 	}
-	return rs.Body, nil
+	if rs.StatusCode == 200 {
+		return rs.Body, nil
+	} else {
+		rs.Body.Close()
+		return nil, newPathError("ReadStream", path, rs.StatusCode)
+	}
 }
 
 func (c *Client) Write(path string, data []byte, _ os.FileMode) error {


### PR DESCRIPTION
In `Read`/`ReadStream` no HTTP response code handling is done. The expected behaviour IMO is to  promote 404 and similar errors to actual `err` responses.