### PR TITLE
Bug #14 fixed

### DIFF
--- a/digestAuth.go
+++ b/digestAuth.go
@@ -77,7 +77,12 @@ func getDigestAuthorization(digestParts map[string]string) string {
 	nonceCount := 00000001
 	cnonce := getCnonce()
 	response := getMD5(fmt.Sprintf("%s:%s:%v:%s:%s:%s", ha1, d["nonce"], nonceCount, cnonce, d["qop"], ha2))
-	authorization := fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc="%v", qop="%s", response="%s", opaque="%s"`,
-		d["username"], d["realm"], d["nonce"], d["uri"], cnonce, nonceCount, d["qop"], response, d["opaque"])
+	authorization := fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", qop=%s, nc=%v, cnonce="%s", response="%s"`,
+		d["username"], d["realm"], d["nonce"], d["uri"], d["qop"], nonceCount, cnonce, response)
+
+	if d["opaque"] != "" {
+		authorization += fmt.Sprintf(`, opaque="%s"`, d["opaque"])
+	}
+
 	return authorization
 }


### PR DESCRIPTION
The problem was that `Apache HTTPS Server` does not provide `opaque` field in `401 Unauthorized` response, but `gowebdav` trying to read it, and to add this field to `Authorization` header of the next request.

This is example of `gowebdav <--> Apache HTTPS Server` interaction to visualize problem and show the solution:

**Client request**
```
PROPFIND /user HTTP/1.0
Host: mydav.me
```

**Server response**
```
Connection →       Keep-Alive
Content-Length →   457
Content-Type →     text/html; charset=iso-8859-1
Date →             Wed, 20 Jun 2018 00:08:07 GMT
Keep-Alive →       timeout=5, max=100
Server →           Apache/2.4.18 (Ubuntu)
WWW-Authenticate → Digest realm="webdav", 
                   nonce="luTmlwdvBQA=7a7e41a1027643ba1f7b3c34d4e52133e2ee6a3c", 
                   algorithm=MD5, 
                   qop=auth
<!DOCTYPE HTML>
<html><head>
<title>401 Unauthorized</title>
</head><body>
<h1>Unauthorized</h1>
<p>This server could not verify that you
are authorized to access the document
requested.  Either you supplied the wrong
credentials (e.g., bad password), or your
browser doesn't understand how to supply
the credentials required.</p>
<hr>
<address>Apache/2.4.18 (Ubuntu) Server at mydav.me Port 443</address>
</body></html>
```

**OLD Client request**
```
....
Authorization → Digest username="user", 
                realm="webdav", 
                nonce="luTmlwdvBQA=7a7e41a1027643ba1f7b3c34d4e52133e2ee6a3c", 
                uri="/user/", 
                qop="auth", 
                nc="1", 
                cnonce="558ea95e33ae7443", 
                response="bca502a89e83835f723320019706a606"
                opaque=""
```

**NEW Client request**
```
....
Authorization → Digest username="user", 
                realm="webdav", 
                nonce="luTmlwdvBQA=7a7e41a1027643ba1f7b3c34d4e52133e2ee6a3c", 
                uri="/user/", 
                qop=auth, 
                nc=1, 
                cnonce="558ea95e33ae7443", 
                response="bca502a89e83835f723320019706a606"
```

As you see, following changes was done:
1) empty `opaque` field was removed
2) quotes for `qop` field was removed (server require this field without quotes)
3) qoutes for `nc` field was removed (this field is number that is why it should be specified without quotes)

This changes allows to correctly authorize our request, and fix bug #14 