### PR TITLE
Creating parent collection method was added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: go
 
 go:
   - "1.x"
+
+script:
+  - go get ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: go
 go:
   - "1.x"
 
-script:
+install:
   - go get ./...
+
+script:
+  - go test -v --short ./...

--- a/client.go
+++ b/client.go
@@ -346,13 +346,14 @@ func (c *Client) Write(path string, data []byte, _ os.FileMode) error {
 		return nil
 
 	case 409:
-		if err := c.createParentCollection(path); err == nil {
-			s = c.put(path, bytes.NewReader(data))
-			if s == 200 || s == 201 || s == 204 {
-				return nil
-			}
-		} else {
+		err := c.createParentCollection(path)
+		if err != nil {
 			return err
+		}
+
+		s = c.put(path, bytes.NewReader(data))
+		if s == 200 || s == 201 || s == 204 {
+			return nil
 		}
 	}
 

--- a/requests.go
+++ b/requests.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 	"path"
-	"github.com/pkg/errors"
 )
 
 func (c *Client) req(method, path string, body io.Reader, intercept func(*http.Request)) (req *http.Response, err error) {
@@ -157,13 +156,6 @@ func (c *Client) put(path string, stream io.Reader) int {
 }
 
 func (c *Client) createParentCollection(itemPath string) (err error) {
-
 	parentPath := path.Dir(itemPath)
-
-	err = c.MkdirAll(parentPath, 0755)
-	if err != nil {
-		return errors.Wrap(err, "can't create parent collection")
-	}
-
-	return nil
+	return c.MkdirAll(parentPath, 0755)
 }

--- a/requests.go
+++ b/requests.go
@@ -135,7 +135,12 @@ func (c *Client) copymove(method string, oldpath string, newpath string, overwri
 		log(fmt.Sprintf(" TODO handle %s - %s multistatus result %s", method, oldpath, String(data)))
 
 	case 409:
-		// TODO create dst path
+		err := c.createParentCollection(newpath)
+		if err != nil {
+			return err
+		}
+
+		return c.copymove(method, oldpath, newpath, overwrite)
 	}
 
 	return newPathError(method, oldpath, s)

--- a/requests.go
+++ b/requests.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"path"
+	"github.com/pkg/errors"
 )
 
 func (c *Client) req(method, path string, body io.Reader, intercept func(*http.Request)) (req *http.Response, err error) {
@@ -147,4 +149,16 @@ func (c *Client) put(path string, stream io.Reader) int {
 	}
 
 	return rs.StatusCode
+}
+
+func (c *Client) createParentCollection(itemPath string) (err error) {
+
+	parentPath := path.Dir(itemPath)
+
+	err = c.MkdirAll(parentPath, 0755)
+	if err != nil {
+		return errors.Wrap(err, "can't create parent collection")
+	}
+
+	return nil
 }


### PR DESCRIPTION
When I reading sources of `gowebdav` I found that `Client.createParentCollection()` method is required in some places, and marked with `TODO` statements.
So, in this pull request I do:
1. Add `Client.createParentCollection(itemPath string) error` method to `Client`'s structure
2. Use this method inside `Client.Write(path string, data []byte, _  os.FileMode) error` method in case of `409` response
3. Use this method inside `Client.WriteStream(path string, stream io.Reader, _  os.FileMode) error` method
4. Use this method inside `Client.copymove(method string, oldpath string, newpath string, overwrite bool) error` method in case of `409` response

_NOTE_: I think `Client.Write()` and `Client.WriteStream()` methods should be refactored to use `c.createParentCollection()` in the same way, because now `Client.WriteStream()` method always trying to create parent collection but `Client.Write()` method trying to create parent collection only in case of `409` error

**UPDATE**:
Also `.travis.yml` file was changed to install dependencies before tests running.