### PR TITLE
Added check of parentPath in createParentCollection

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -160,7 +160,7 @@ func (c *Client) put(path string, stream io.Reader) int {
 
 func (c *Client) createParentCollection(itemPath string) (err error) {
 	parentPath := path.Dir(itemPath)
-	if parentPath == "." {
+	if parentPath == "." || parentPath == "/" {
 		return nil
 	}
 

--- a/requests.go
+++ b/requests.go
@@ -160,5 +160,9 @@ func (c *Client) put(path string, stream io.Reader) int {
 
 func (c *Client) createParentCollection(itemPath string) (err error) {
 	parentPath := path.Dir(itemPath)
+	if parentPath == "." {
+		return nil
+	}
+
 	return c.MkdirAll(parentPath, 0755)
 }


### PR DESCRIPTION
Hi,

I discovered the problem that createParentCollection might be called with no or root directory, resulting in errors with MkdirAll. The attached commit simply adds a check for this.

Best Regards