### PR TITLE
Add File.Path to return the full path

### DIFF
--- a/file.go
+++ b/file.go
@@ -17,6 +17,11 @@ type File struct {
 	isdir       bool
 }
 
+// Path returns the full path of a file
+func (f File) Path() string {
+	return f.path
+}
+
 // Name returns the name of a file
 func (f File) Name() string {
 	return f.name


### PR DESCRIPTION
Very useful when iterating over ReadDir results and wanting to do some operation on them.