### PR TITLE
Add ability to define custom interceptors (fixes #35)

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,9 +15,10 @@ import (
 
 // Client defines our structure
 type Client struct {
-	root    string
-	headers http.Header
-	c       *http.Client
+	root        string
+	headers     http.Header
+	interceptor func(method string, rq *http.Request)
+	c           *http.Client
 
 	authMutex sync.Mutex
 	auth      Authenticator
@@ -58,12 +59,17 @@ func (n *NoAuth) Authorize(req *http.Request, method string, path string) {
 
 // NewClient creates a new instance of client
 func NewClient(uri, user, pw string) *Client {
-	return &Client{FixSlash(uri), make(http.Header), &http.Client{}, sync.Mutex{}, &NoAuth{user, pw}}
+	return &Client{FixSlash(uri), make(http.Header), nil, &http.Client{}, sync.Mutex{}, &NoAuth{user, pw}}
 }
 
 // SetHeader lets us set arbitrary headers for a given client
 func (c *Client) SetHeader(key, value string) {
 	c.headers.Add(key, value)
+}
+
+// SetInterceptor lets us set an arbitrary interceptor for a given client
+func (c *Client) SetInterceptor(interceptor func(method string, rq *http.Request)) {
+	c.interceptor = interceptor
 }
 
 // SetTimeout exposes the ability to set a time limit for requests

--- a/requests.go
+++ b/requests.go
@@ -43,6 +43,10 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 		intercept(r)
 	}
 
+	if c.interceptor != nil {
+		c.interceptor(method, r)
+	}
+
 	rs, err := c.c.Do(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #35 

This adds the ability to define custom interceptors, like so:

```go
// Disable chunked encoding for better compatibility
	webDAVClient.SetInterceptor(func(method string, rq *http.Request) {
		if method == "PUT" && rq.Body != nil {
			b, err := ioutil.ReadAll(rq.Body)
			if err != nil {
				panic(err)
			}

			rq.ContentLength = int64(len(b))

			rq.Body = ioutil.NopCloser(bytes.NewReader(b))
		}
	})
```

See https://github.com/pojntfx/growlapse/blob/main/main.go#L145-L157 for a usage example. This allows to for example upload to servers which don't have chunked encoding support, such as the public Nextcloud instances hosted by [Hetzner](https://www.hetzner.com/storage/storage-share).