### PR TITLE
Handle request errors in copymove

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -142,7 +142,9 @@ func (c *Client) doCopyMove(method string, oldpath string, newpath string, overw
 
 func (c *Client) copymove(method string, oldpath string, newpath string, overwrite bool) error {
 	s, data := c.doCopyMove(method, oldpath, newpath, overwrite)
-	defer data.Close()
+	if data != nil {
+		defer data.Close()
+	}
 
 	switch s {
 	case 201, 204:


### PR DESCRIPTION
I've been connecting to my Synology's WebDAV and have been encountering semi-regular panics with the following stacktrace:

```plaintext
github.com/studio-b12/gowebdav.(*Client).copymove(0xc0004ec140, 0x12c5bd5, 0x4, 0xc01a132dc0, 0x4e, 0xc0190efe80, 0x3a, 0x1, 0x0, 0x0)
        /home/runner/go/pkg/mod/github.com/studio-b12/gowebdav@v0.0.0-20210203212356-8244b5a5f51a/requests.go:141 +0xbc
github.com/studio-b12/gowebdav.(*Client).Rename(...)
        /home/runner/go/pkg/mod/github.com/studio-b12/gowebdav@v0.0.0-20210203212356-8244b5a5f51a/client.go:302
…
```

It appears that this is simply due to not properly handling request errors during copy/move.