### PR TITLE
Fix index out of range runtime error when empty string is provided to FixSlashes

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -32,7 +32,7 @@ func newPathErrorErr(op string, path string, err error) error {
 	}
 }
 
-// PathEscape escapes all segemnts of a given path
+// PathEscape escapes all segments of a given path
 func PathEscape(path string) string {
 	s := strings.Split(path, "/")
 	for i, e := range s {

--- a/utils.go
+++ b/utils.go
@@ -51,9 +51,10 @@ func FixSlash(s string) string {
 
 // FixSlashes appends and prepends a / if they are missing
 func FixSlashes(s string) string {
-	if s[0] != '/' {
+	if !strings.HasPrefix(s, "/") {
 		s = "/" + s
 	}
+
 	return FixSlash(s)
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -43,3 +43,25 @@ func TestEscapeURL(t *testing.T) {
 		t.Error("expected: " + ex + " got: " + u.String())
 	}
 }
+
+func TestFixSlashes(t *testing.T) {
+	expected := "/"
+
+	if got := FixSlashes(""); got != expected {
+		t.Errorf("expected: %q, got: %q", expected, got)
+	}
+
+	expected = "/path/"
+
+	if got := FixSlashes("path"); got != expected {
+		t.Errorf("expected: %q, got: %q", expected, got)
+	}
+
+	if got := FixSlashes("/path"); got != expected {
+		t.Errorf("expected: %q, got: %q", expected, got)
+	}
+
+	if got := FixSlashes("path/"); got != expected {
+		t.Errorf("expected: %q, got: %q", expected, got)
+	}
+}


### PR DESCRIPTION
Fix index out of range runtime error when empty string is provided to FixSlashes. When someone provides an empty string to e.g. ReadDir, this will cause a runtime error in FixSlashes.