### PR TITLE
Add GitHub Actions Workflow for Unit Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Unit Tests
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "*"
+    paths-ignore:
+      - "**.md"
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goversion:
+          - "1.17"
+          - "1.16"
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.goversion }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Get dependencies
+        run: go get ./...
+      - name: Run Unit Tests
+        run: go test -v -cover -race ./...


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow configuration to perform go unit tests on push and pull requests. This might become handy due to the integration between GitHub repositories and GitHub Actions to validate pull requests and code pushes alongside the TravisCI pipeline.

All unit tests are performed on the latest supported go versions (`1.16` and `1.17` in this case).