### PR TITLE
Fix crash when no body is passed to `Client#req`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.vscode/


### PR DESCRIPTION
Well, I noticed that a nil pointer panic is caused under some circumstances when `Client#req` is called with `body` as `nil`.  
This PR should fix that problem.

Also, in order of the changes I've removed the nil check from the request inside the non-auth retry condition, because `retryBuf` is always `nil` when `body` was `nil` initially.

Additionally, I've added the `.vscode/` directory to the gitignore, just for convenience when working with VSC.