### PR TITLE
Improve Error Handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,49 @@
+package gowebdav
+
+import (
+	"fmt"
+	"os"
+)
+
+// StatusError implements error and wraps
+// an erroneous status code.
+type StatusError struct {
+	Status int
+}
+
+func (se StatusError) Error() string {
+	return fmt.Sprintf("%d", se.Status)
+}
+
+// IsErrCode returns true if the given error
+// is an os.PathError wrapping a StatusError
+// with the given status code.
+func IsErrCode(err error, code int) bool {
+	if pe, ok := err.(*os.PathError); ok {
+		se, ok := pe.Err.(StatusError)
+		return ok && se.Status == code
+	}
+	return false
+}
+
+// IsErrNotFound is shorthand for IsErrCode
+// for status 404.
+func IsErrNotFound(err error) bool {
+	return IsErrCode(err, 404)
+}
+
+func newPathError(op string, path string, statusCode int) error {
+	return &os.PathError{
+		Op:   op,
+		Path: path,
+		Err:  StatusError{statusCode},
+	}
+}
+
+func newPathErrorErr(op string, path string, err error) error {
+	return &os.PathError{
+		Op:   op,
+		Path: path,
+		Err:  err,
+	}
+}

--- a/requests.go
+++ b/requests.go
@@ -14,10 +14,6 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 	var retryBuf io.Reader
 
 	if body != nil {
-		// Because Request#Do closes closable streams, Seeker#Seek
-		// will fail on retry because stream is already  closed.
-		// This inhibits the closing of the passed stream.
-		body = closeInhibitor{body}
 		// If the authorization fails, we will need to restart reading
 		// from the passed body stream.
 		// When body is seekable, use seek to reset the streams

--- a/requests.go
+++ b/requests.go
@@ -135,7 +135,7 @@ func (c *Client) propfind(path string, self bool, body string, resp interface{},
 	defer rs.Body.Close()
 
 	if rs.StatusCode != 207 {
-		return fmt.Errorf("%s - %s %s", rs.Status, "PROPFIND", path)
+		return newPathError("PROPFIND", path, rs.StatusCode)
 	}
 
 	return parseXML(rs.Body, resp, parse)

--- a/requests.go
+++ b/requests.go
@@ -14,6 +14,10 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 	var retryBuf io.Reader
 
 	if body != nil {
+		// Because Request#Do closes closable streams, Seeker#Seek
+		// will fail on retry because stream is already  closed.
+		// This inhibits the closing of the passed stream.
+		body = closeInhibitor{body}
 		// If the authorization fails, we will need to restart reading
 		// from the passed body stream.
 		// When body is seekable, use seek to reset the streams

--- a/utils.go
+++ b/utils.go
@@ -116,14 +116,3 @@ func (l *limitedReadCloser) Read(buf []byte) (int, error) {
 func (l *limitedReadCloser) Close() error {
 	return l.rc.Close()
 }
-
-// closeInhibitor implements io.Closer and
-// wraps a Reader. When Close() is performed
-// on it, it will simply be silently rejected.
-type closeInhibitor struct {
-	io.Reader
-}
-
-func (ci closeInhibitor) Close() error {
-	return nil
-}

--- a/utils.go
+++ b/utils.go
@@ -133,3 +133,14 @@ func (l *limitedReadCloser) Read(buf []byte) (int, error) {
 func (l *limitedReadCloser) Close() error {
 	return l.rc.Close()
 }
+
+// closeInhibitor implements io.Closer and
+// wraps a Reader. When Close() is performed
+// on it, it will simply be silently rejected.
+type closeInhibitor struct {
+	io.Reader
+}
+
+func (ci closeInhibitor) Close() error {
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -14,22 +13,6 @@ import (
 
 func log(msg interface{}) {
 	fmt.Println(msg)
-}
-
-func newPathError(op string, path string, statusCode int) error {
-	return &os.PathError{
-		Op:   op,
-		Path: path,
-		Err:  fmt.Errorf("%d", statusCode),
-	}
-}
-
-func newPathErrorErr(op string, path string, err error) error {
-	return &os.PathError{
-		Op:   op,
-		Path: path,
-		Err:  err,
-	}
 }
 
 // PathEscape escapes all segments of a given path


### PR DESCRIPTION
I found some time to try to tackle the error handling issue described in #28.

Therefore, all request methods which only returned status code do now return proper error values as well. Also, path errors now contain an instance of `StatusError` which contains the erroneous status code. This makes handling specific errors more trivial.

As well, I put all error related functions and structures into `errors.go` to give a better overview over the codebase.

While testing, I also noticed that `Client#req` fails when a file stream is passed as body and the request is repeatet due to an authentication error. I found out that - for whatever reason - `http.Client#Do` closes the passed `io.Closer` stream.

Here is a quick demonstration of this behavior: https://go.dev/play/p/OouD3-GAD0M

This causes `Seek` on the stream to fail after the first request because the file is closed. To inhibit the closing, I wrapped the stream in a struct implementation which overrides `Close` so that it can't be closed by the `Do` method.

Even though I've tested through all methods using the client, I am not completely sure if my changes introduce any unwanted side effect, wo it would be nice if you could take a look over it. 😅