### PR TITLE
Prevent body from being closed by the Request RoundTripper

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -14,6 +14,11 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 	var retryBuf io.Reader
 
 	if body != nil {
+		// Because Request#Do closes closable streams, Seeker#Seek
+		// will fail on retry because stream is already  closed.
+		// This inhibits the closing of the passed stream on passing
+		// it to the RoundTripper and closes the stream after we
+		// are done with the body content.
 		if cl, ok := body.(io.Closer); ok {
 			body = closeInhibitor{body}
 			defer cl.Close()

--- a/requests.go
+++ b/requests.go
@@ -14,6 +14,10 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 	var retryBuf io.Reader
 
 	if body != nil {
+		// Because Request#Do closes closable streams, Seeker#Seek
+		// will fail on retry because stream is already  closed.
+		// This inhibits the closing of the passed stream.
+		body = closeInhibitor{body}
 		// If the authorization fails, we will need to restart reading
 		// from the passed body stream.
 		// When body is seekable, use seek to reset the streams

--- a/utils.go
+++ b/utils.go
@@ -133,3 +133,14 @@ func (l *limitedReadCloser) Read(buf []byte) (int, error) {
 func (l *limitedReadCloser) Close() error {
 	return l.rc.Close()
 }
+
+// closeInhibitor implements io.Closer and
+// wraps a Reader. When Close() is performed
+// on it, it will simply be silently rejected.
+type closeInhibitor struct {
+	io.Reader
+}
+
+func (ci closeInhibitor) Close() error {
+	return nil
+}


### PR DESCRIPTION
Because the Request RoundTripper closes passed body streams if they implement `io.Close`, seeking the body on re-trying the request after an authentication error fails because the body stream is already closed.

This implementation prevents the RoudTripper from closing the body so we can postpone the closing until we are done with the body stream.