### PR TITLE
feat: handle 404 on propfind

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -130,7 +130,10 @@ func (c *Client) propfind(path string, self bool, body string, resp interface{},
 	}
 	defer rs.Body.Close()
 
-	if rs.StatusCode != 207 {
+	switch rs.StatusCode {
+	case 207:
+		return newPathError("PROPFIND", path, rs.StatusCode)
+	case 404:
 		return newPathError("PROPFIND", path, rs.StatusCode)
 	}
 


### PR DESCRIPTION
Client.Stat was not returning a proper Go err for not found files, the
ideal way to check this is using `errors.Is(err, fs.ErrNotExist)` but
the client was returning a generic error.

I've updated the `propfind` to take 404 errors into account, retuning
the above error making easier to evaluate that kind of situations.