### PR TITLE
Returns pointer to FileInfo from ReadDir

### DIFF
--- a/client.go
+++ b/client.go
@@ -151,7 +151,7 @@ func (c *Client) ReadDir(path string) ([]os.FileInfo, error) {
 				f.isdir = false
 			}
 
-			files = append(files, *f)
+			files = append(files, f)
 		}
 
 		r.Props = nil


### PR DESCRIPTION
Returns pointer to `os.FileInfo` from `ReadDir()` - same as Stat does. This would than ensure compatibility of return types for `Stat()` and `ReadDir()`. Now are different. 