### PR TITLE
Provide content length for the put method

### DIFF
--- a/client.go
+++ b/client.go
@@ -435,10 +435,14 @@ func (c *Client) WriteStream(path string, stream io.Reader, _ os.FileMode) (err 
 			return err
 		}
 	} else {
-		contentLength, err = io.Copy(io.Discard, stream)
+		buffer := bytes.NewBuffer(make([]byte, 0, 1024 * 1024 /* 1MB */))
+		
+		contentLength, err = io.Copy(buffer, stream)
 		if err != nil {
 			return err
 		}
+
+		stream = buffer
 	}
 
 	s, err := c.put(path, stream, contentLength)

--- a/requests.go
+++ b/requests.go
@@ -160,8 +160,10 @@ func (c *Client) copymove(method string, oldpath string, newpath string, overwri
 	return NewPathError(method, oldpath, s)
 }
 
-func (c *Client) put(path string, stream io.Reader) (status int, err error) {
-	rs, err := c.req("PUT", path, stream, nil)
+func (c *Client) put(path string, stream io.Reader, contentLength int64) (status int, err error) {
+	rs, err := c.req("PUT", path, stream, func(r *http.Request) {
+		r.ContentLength = contentLength
+	})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Since there is some webdav server implementation (such as nextcloud) give unexpected behavior when there is no content length is set in the put request. Therefore, I introduce the contentLength parameter to the `*Client.put()` method to provide the correct content length of the body to the server to prevent the behavior mention above.