### PR TITLE
Gets error code from error as int

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -327,6 +327,7 @@ func TestReadStreamRangeUnkownLength(t *testing.T) {
 func TestStat(t *testing.T) {
 	cli, srv, _, _ := newServer(t)
 	defer srv.Close()
+	wantErrCode := 404
 
 	info, err := cli.Stat("/hello.txt")
 	if err != nil {
@@ -342,6 +343,9 @@ func TestStat(t *testing.T) {
 	}
 	if !IsErrNotFound(err) {
 		t.Fatalf("got: %v, want 404 error", err)
+	}
+	if GetStatusCode(err) != wantErrCode {
+		t.Fatalf("got: %v, want %d", err, wantErrCode)
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package gowebdav
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 )
 
@@ -54,4 +55,17 @@ func NewPathErrorErr(op string, path string, err error) error {
 		Path: path,
 		Err:  err,
 	}
+}
+
+// GetStatusCode returns status code of the error
+func GetStatusCode(err error) int {
+	var pe *os.PathError
+	if !errors.As(err, &pe) {
+		return http.StatusInternalServerError
+	}
+	var se StatusError
+	if !errors.As(pe.Err, &se) {
+		return http.StatusInternalServerError
+	}
+	return se.Status
 }


### PR DESCRIPTION
Introduces a method that returns error status code from given error of type integer