### PR TITLE
Add support for stale directive for digest authenticator

### DIFF
--- a/digestAuth.go
+++ b/digestAuth.go
@@ -173,8 +173,8 @@ func isStaled(rs *http.Response) bool {
 	if len(header) > 0 {
 		directives := strings.Split(header, ",")
 		for i := range directives {
-			key, value, _ := strings.Cut(strings.Trim(directives[i], " "), "=")
-			if strings.EqualFold(key, "stale") {
+			name, value, _ := strings.Cut(strings.Trim(directives[i], " "), "=")
+			if strings.EqualFold(name, "stale") {
 				return strings.EqualFold(value, "true")
 			}
 		}

--- a/digestAuth_test.go
+++ b/digestAuth_test.go
@@ -1,6 +1,7 @@
 package gowebdav
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -31,5 +32,44 @@ func TestDigestAuthAuthorize(t *testing.T) {
 	ex := `Digest username="user", realm="", nonce="", uri="/", nc=1, cnonce="`
 	if strings.Index(rq.Header.Get("Authorization"), ex) != 0 {
 		t.Error("got wrong Authorization header: " + rq.Header.Get("Authorization"))
+	}
+}
+
+func TestDigestAuthVerify(t *testing.T) {
+	a := &DigestAuth{user: "user", pw: "password", digestParts: make(map[string]string, 0)}
+
+	// Nominal test: 200 OK response
+	rs := &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+	}
+
+	redo, err := a.Verify(nil, rs, "/")
+
+	if err != nil {
+		t.Errorf("got error: %v, want nil", err)
+	}
+
+	if redo {
+		t.Errorf("got redo: %t, want false", redo)
+	}
+
+	// Digest expiration test: 401 Unauthorized response with stale directive in WWW-Authenticate header
+	rs = &http.Response{
+		Status:     "401 Unauthorized",
+		StatusCode: http.StatusUnauthorized,
+		Header: http.Header{
+			"Www-Authenticate": []string{"Digest realm=\"webdav\", nonce=\"YVvALpkdBgA=931bbf2b6fa9dda227361dba38a735f005fd9f97\", algorithm=MD5, qop=\"auth\", stale=true"},
+		},
+	}
+
+	redo, err = a.Verify(nil, rs, "/")
+
+	if !errors.Is(err, ErrAuthChanged) {
+		t.Errorf("got error: %v, want ErrAuthChanged", err)
+	}
+
+	if !redo {
+		t.Errorf("got redo: %t, want true", redo)
 	}
 }


### PR DESCRIPTION
Hi studio-b12 members !

First of all, I'd like to thank you for this wonderful/easy-to-use Webdav Go package 😃 

I'm opening this PR because I recently faced an issue trying to connect to a Webdav server using Digest auth mechanism.
Client successfully connected to this server using digest authenticator, but after some time it was rejected by the server with 401 status codes.

I took a look at the [RFC2617](https://www.ietf.org/rfc/rfc2617.txt) (Section `3.2.1 The WWW-Authenticate Response Header`), and it seems that the server can invalidate the generated `nonce` value after some time (which is my case). However, in such case, the `stale` directive is added to the `WWW-Authenticate` header, indicating to the client to re-authenticate without reprompting the user for username and password.

So I forked your project and did a small change in the `Verify` method of the `DigestAuth` authenticator to handle such case. I thought you might be interested with these changes 😉 