### PR TITLE
Feat/reduce memory use for authorizer

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -159,9 +159,14 @@ func (a *authorizer) NewAuthenticator(body io.Reader) (Authenticator, io.Reader)
 		// cursor to the start.
 		// Otherwise, copy the stream into a buffer while uploading
 		// and use the buffers content on retry.
-		if _, ok := retryBuf.(io.Seeker); ok {
+		switch body.(type) {
+		case io.Seeker:
 			body = io.NopCloser(body)
-		} else {
+		case *bytes.Buffer:
+			buffer := &bytes.Buffer{}
+			*buffer = *body.(*bytes.Buffer)
+			retryBuf = buffer
+		default:
 			buff := &bytes.Buffer{}
 			retryBuf = buff
 			body = io.TeeReader(body, buff)

--- a/auth.go
+++ b/auth.go
@@ -157,6 +157,8 @@ func (a *authorizer) NewAuthenticator(body io.Reader) (Authenticator, io.Reader)
 		// from the passed body stream.
 		// When body is seekable, use seek to reset the streams
 		// cursor to the start.
+		// If the body is a bytes.Buffer, create a new buffer and perform a shallow copy
+		// of the original buffer's content to the new one. Use the new buffer for retries.
 		// Otherwise, copy the stream into a buffer while uploading
 		// and use the buffers content on retry.
 		switch body.(type) {


### PR DESCRIPTION
During the pervious content length issue, I also find that the authorizer will try to copy the whole data to buffer if the body is not a io.Seeker, which use extra memory when the body is bytes.Buffer.

In this pr, I try to shallow copy a bytes.Buffer for the retryBuf which does not need to copy entire buffer to memory but keep a separate copy for retry.