### PR TITLE
fix: harden WebDAV auth/parsing and correct range, netrc, and CLI PUT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ The default implementation negotiates the algorithm based on the user's preferen
 Out-of-box authentication support for:
 
 * [BasicAuth](https://en.wikipedia.org/wiki/Basic_access_authentication)
+* [Bearer Token](https://datatracker.ietf.org/doc/html/rfc6750)
 * [DigestAuth](https://en.wikipedia.org/wiki/Digest_access_authentication)
 * [MS-PASS](https://github.com/studio-b12/gowebdav/pull/70#issuecomment-1421713726)
 * [WIP Kerberos](https://github.com/studio-b12/gowebdav/pull/71#issuecomment-1416465334)
-* [WIP Bearer Token](https://github.com/studio-b12/gowebdav/issues/61)
 
 ## Usage
 
@@ -48,6 +48,15 @@ c.Connect()
 After you can use this `Client` to perform actions, described below.
 
 **NOTICE:** We will not check for errors in the examples, to focus you on the `gowebdav` library's code, but you should do it in your code!
+
+### Connect with a Bearer token
+```go
+root := "https://webdav.mydomain.me"
+token := "token"
+
+c := gowebdav.NewBearerAuthClient(root, token)
+c.Connect()
+```
 
 ### Create path on a WebDAV server
 ```go

--- a/auth.go
+++ b/auth.go
@@ -118,6 +118,10 @@ func NewAutoAuth(login string, secret string) Authorizer {
 		return NewDigestAuth(login, secret, rs)
 	})
 
+	az.AddAuthenticator("bearer", func(c *http.Client, rs *http.Response, path string) (auth Authenticator, err error) {
+		return NewBearerAuth(secret), nil
+	})
+
 	az.AddAuthenticator("passport1.4", func(c *http.Client, rs *http.Response, path string) (auth Authenticator, err error) {
 		return NewPassportAuth(c, login, secret, rs.Request.URL.String(), &rs.Header)
 	})

--- a/bearerAuth.go
+++ b/bearerAuth.go
@@ -1,0 +1,50 @@
+package gowebdav
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BearerAuth structure holds our bearer token
+type BearerAuth struct {
+	token string
+}
+
+// NewBearerAuth creates a new bearer token authenticator.
+func NewBearerAuth(token string) Authenticator {
+	return &BearerAuth{token: token}
+}
+
+// NewBearerAuthClient creates a new client instance with preemptive bearer authentication.
+func NewBearerAuthClient(uri, token string) *Client {
+	return NewAuthClient(uri, NewPreemptiveAuth(NewBearerAuth(token)))
+}
+
+// Authorize the current request
+func (b *BearerAuth) Authorize(c *http.Client, rq *http.Request, path string) error {
+	rq.Header.Set("Authorization", "Bearer "+b.token)
+	return nil
+}
+
+// Verify verifies if the authentication
+func (b *BearerAuth) Verify(c *http.Client, rs *http.Response, path string) (redo bool, err error) {
+	if rs.StatusCode == http.StatusUnauthorized {
+		err = NewPathError("Authorize", path, rs.StatusCode)
+	}
+	return
+}
+
+// Close cleans up all resources
+func (b *BearerAuth) Close() error {
+	return nil
+}
+
+// Clone creates a Copy of itself
+func (b *BearerAuth) Clone() Authenticator {
+	return b
+}
+
+// String toString
+func (b *BearerAuth) String() string {
+	return fmt.Sprintf("BearerAuth token: %t", b.token != "")
+}

--- a/bearerAuth_test.go
+++ b/bearerAuth_test.go
@@ -1,0 +1,91 @@
+package gowebdav
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func bearerAuthHandler(token string, h http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer "+token {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", `Bearer realm="dav"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+}
+
+func TestNewBearerAuth(t *testing.T) {
+	a := NewBearerAuth("token").(*BearerAuth)
+
+	ex := "BearerAuth token: true"
+	if a.String() != ex {
+		t.Error("expected: " + ex + " got: " + a.String())
+	}
+
+	if a.Clone() != a {
+		t.Error("expected the same instance")
+	}
+
+	if a.Close() != nil {
+		t.Error("expected close without errors")
+	}
+}
+
+func TestBearerAuthAuthorize(t *testing.T) {
+	a := NewBearerAuth("token")
+	rq, _ := http.NewRequest("GET", "http://localhost/", nil)
+	if err := a.Authorize(nil, rq, "/"); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if rq.Header.Get("Authorization") != "Bearer token" {
+		t.Error("got wrong Authorization header: " + rq.Header.Get("Authorization"))
+	}
+}
+
+func TestPreemptiveBearerAuth(t *testing.T) {
+	auth := NewPreemptiveAuth(NewBearerAuth("token"))
+	n, b := auth.NewAuthenticator(nil)
+	if b != nil {
+		t.Error("expected body to be nil")
+	}
+	if n == nil {
+		t.Fatal("expected authenticator")
+	}
+
+	srv, _, _ := newAuthSrv(t, func(h http.Handler) http.HandlerFunc {
+		return bearerAuthHandler("token", h)
+	})
+	defer srv.Close()
+	cli := NewAuthClient(srv.URL, auth)
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("got error: %v, want nil", err)
+	}
+}
+
+func TestBearerAutoAuthNegotiation(t *testing.T) {
+	srv := httptest.NewServer(bearerAuthHandler("token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "", "token")
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("got error: %v, want nil", err)
+	}
+}
+
+func TestNewBearerAuthClient(t *testing.T) {
+	srv := httptest.NewServer(bearerAuthHandler("token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+	defer srv.Close()
+
+	cli := NewBearerAuthClient(srv.URL, "token")
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("got error: %v, want nil", err)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ func (c *Client) Stat(path string) (os.FileInfo, error) {
 
 	if err != nil {
 		if _, ok := err.(*os.PathError); !ok {
-			err = NewPathErrorErr("ReadDir", path, err)
+			err = NewPathErrorErr("Stat", path, err)
 		}
 	}
 	return f, err
@@ -241,7 +241,7 @@ func (c *Client) Remove(path string) error {
 func (c *Client) RemoveAll(path string) error {
 	rs, err := c.req("DELETE", path, nil, nil)
 	if err != nil {
-		return NewPathError("Remove", path, 400)
+		return NewPathErrorErr("Remove", path, err)
 	}
 	err = rs.Body.Close()
 	if err != nil {
@@ -374,15 +374,20 @@ func (c *Client) ReadStreamRange(path string, offset, length int64) (io.ReadClos
 	if rs.StatusCode == 200 {
 		// discard first 'offset' bytes.
 		if _, err := io.Copy(io.Discard, io.LimitReader(rs.Body, offset)); err != nil {
+			rs.Body.Close()
 			return nil, NewPathErrorErr("ReadStreamRange", path, err)
 		}
 
+		if length == 0 {
+			return rs.Body, nil
+		}
+
 		// return a io.ReadCloser that is limited to `length` bytes.
-		return &limitedReadCloser{rc: rs.Body, remaining: int(length)}, nil
+		return &limitedReadCloser{rc: rs.Body, remaining: length}, nil
 	}
 
 	rs.Body.Close()
-	return nil, NewPathError("ReadStream", path, rs.StatusCode)
+	return nil, NewPathError("ReadStreamRange", path, rs.StatusCode)
 }
 
 // Write writes data to a given path

--- a/cmd/gowebdav/main.go
+++ b/cmd/gowebdav/main.go
@@ -205,7 +205,7 @@ func cmdPut(c *d.Client, p0, p1 string) (err error) {
 			return
 		}
 		if !d.IsErrNotFound(err) && fi.IsDir() {
-			p0 = path.Join(p0, p1)
+			p0 = path.Join(p0, filepath.Base(p1))
 		}
 	}
 

--- a/cmd/gowebdav/main.go
+++ b/cmd/gowebdav/main.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"strings"
 
-	d "github.com/studio-b12/gowebdav"
+	d "github.com/wxk6b1203/gowebdav"
 )
 
 func main() {

--- a/cmd/gowebdav/main_test.go
+++ b/cmd/gowebdav/main_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	d "github.com/studio-b12/gowebdav"
+	d "github.com/wxk6b1203/gowebdav"
 )
 
 func TestCmdPutUsesLocalBaseNameForRemoteDirectory(t *testing.T) {

--- a/cmd/gowebdav/main_test.go
+++ b/cmd/gowebdav/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	d "github.com/studio-b12/gowebdav"
+)
+
+func TestCmdPutUsesLocalBaseNameForRemoteDirectory(t *testing.T) {
+	var putPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			w.Header().Set("Www-Authenticate", `Basic realm="x"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if user != "user" || pass != "password" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		switch r.Method {
+		case "PROPFIND":
+			w.WriteHeader(207)
+			_, _ = io.WriteString(w, `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/uploads</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:displayname>uploads</d:displayname>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getcontentlength>0</d:getcontentlength>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+		case "MKCOL":
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		case "PUT":
+			putPath = r.URL.Path
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	localPath := filepath.Join(dir, "nested", "local.txt")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+		t.Fatalf("mkdir local dir: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write local file: %v", err)
+	}
+
+	cli := d.NewClient(srv.URL, "user", "password")
+	if err := cmdPut(cli, "/uploads", localPath); err != nil {
+		t.Fatalf("cmdPut: %v", err)
+	}
+	if putPath != "/uploads/local.txt" {
+		t.Fatalf("got put path %q, want /uploads/local.txt", putPath)
+	}
+}

--- a/digestAuth.go
+++ b/digestAuth.go
@@ -66,21 +66,100 @@ func (d *DigestAuth) String() string {
 
 func digestParts(resp *http.Response) map[string]string {
 	result := map[string]string{}
-	if len(resp.Header["Www-Authenticate"]) > 0 {
-		wantedHeaders := []string{"nonce", "realm", "qop", "opaque", "algorithm", "entityBody"}
-		responseHeaders := strings.Split(resp.Header["Www-Authenticate"][0], ",")
-		for _, r := range responseHeaders {
-			for _, w := range wantedHeaders {
-				if strings.Contains(r, w) {
-					result[w] = strings.Trim(
-						strings.SplitN(r, `=`, 2)[1],
-						`"`,
-					)
-				}
+	header := resp.Header.Get("Www-Authenticate")
+	if header == "" {
+		return result
+	}
+
+	if _, params, ok := strings.Cut(header, " "); ok {
+		header = params
+	}
+
+	for _, directive := range splitHeaderDirectives(header) {
+		key, value, ok := strings.Cut(directive, "=")
+		if !ok {
+			continue
+		}
+
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+
+		switch key {
+		case "nonce", "realm", "qop", "opaque", "algorithm", "entitybody":
+			result[key] = value
+		}
+	}
+
+	if qop, ok := result["qop"]; ok {
+		result["qop"] = selectDigestQOP(qop)
+	}
+	if algorithm, ok := result["algorithm"]; ok {
+		result["algorithm"] = normalizeDigestAlgorithm(algorithm)
+	}
+
+	return result
+}
+
+func splitHeaderDirectives(header string) []string {
+	var (
+		result  []string
+		current strings.Builder
+		quoted  bool
+	)
+
+	for _, r := range header {
+		switch r {
+		case '"':
+			quoted = !quoted
+			current.WriteRune(r)
+		case ',':
+			if quoted {
+				current.WriteRune(r)
+				continue
+			}
+			part := strings.TrimSpace(current.String())
+			if part != "" {
+				result = append(result, part)
+			}
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	part := strings.TrimSpace(current.String())
+	if part != "" {
+		result = append(result, part)
+	}
+
+	return result
+}
+
+func selectDigestQOP(qop string) string {
+	var firstSupported string
+	for _, token := range strings.Split(qop, ",") {
+		token = strings.ToLower(strings.TrimSpace(token))
+		switch token {
+		case "auth":
+			return "auth"
+		case "auth-int":
+			if firstSupported == "" {
+				firstSupported = token
 			}
 		}
 	}
-	return result
+	return firstSupported
+}
+
+func normalizeDigestAlgorithm(algorithm string) string {
+	switch strings.ToUpper(strings.TrimSpace(algorithm)) {
+	case "MD5":
+		return "MD5"
+	case "MD5-SESS":
+		return "MD5-sess"
+	default:
+		return strings.TrimSpace(algorithm)
+	}
 }
 
 func getMD5(text string) string {
@@ -102,7 +181,7 @@ func getDigestAuthorization(digestParts map[string]string) string {
 	var (
 		ha1        string
 		ha2        string
-		nonceCount = 00000001
+		nonceCount = "00000001"
 		cnonce     = getCnonce()
 		response   string
 	)
@@ -113,9 +192,9 @@ func getDigestAuthorization(digestParts map[string]string) string {
 		ha1 = getMD5(d["username"] + ":" + d["realm"] + ":" + d["password"])
 	case "MD5-sess":
 		ha1 = getMD5(
-			fmt.Sprintf("%s:%v:%s",
+			fmt.Sprintf("%s:%s:%s",
 				getMD5(d["username"]+":"+d["realm"]+":"+d["password"]),
-				nonceCount,
+				d["nonce"],
 				cnonce,
 			),
 		)
@@ -143,7 +222,7 @@ func getDigestAuthorization(digestParts map[string]string) string {
 		)
 	case "auth", "auth-int":
 		response = getMD5(
-			fmt.Sprintf("%s:%s:%v:%s:%s:%s",
+			fmt.Sprintf("%s:%s:%s:%s:%s:%s",
 				ha1,
 				d["nonce"],
 				nonceCount,
@@ -154,7 +233,7 @@ func getDigestAuthorization(digestParts map[string]string) string {
 		)
 	}
 
-	authorization := fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", nc=%v, cnonce="%s", response="%s"`,
+	authorization := fmt.Sprintf(`Digest username="%s", realm="%s", nonce="%s", uri="%s", nc=%s, cnonce="%s", response="%s"`,
 		d["username"], d["realm"], d["nonce"], d["uri"], nonceCount, cnonce, response)
 
 	if d["qop"] != "" {
@@ -163,6 +242,10 @@ func getDigestAuthorization(digestParts map[string]string) string {
 
 	if d["opaque"] != "" {
 		authorization += fmt.Sprintf(`, opaque="%s"`, d["opaque"])
+	}
+
+	if d["algorithm"] != "" {
+		authorization += fmt.Sprintf(`, algorithm=%s`, d["algorithm"])
 	}
 
 	return authorization

--- a/digestAuth_test.go
+++ b/digestAuth_test.go
@@ -2,6 +2,7 @@ package gowebdav
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -29,9 +30,49 @@ func TestDigestAuthAuthorize(t *testing.T) {
 	rq, _ := http.NewRequest("GET", "http://localhost/", nil)
 	a.Authorize(nil, rq, "/")
 	// TODO this is a very lazy test it cuts of cnonce
-	ex := `Digest username="user", realm="", nonce="", uri="/", nc=1, cnonce="`
+	ex := `Digest username="user", realm="", nonce="", uri="/", nc=00000001, cnonce="`
 	if strings.Index(rq.Header.Get("Authorization"), ex) != 0 {
 		t.Error("got wrong Authorization header: " + rq.Header.Get("Authorization"))
+	}
+}
+
+func TestDigestAuthAuthorizeMD5Sess(t *testing.T) {
+	a := &DigestAuth{
+		user: "user",
+		pw:   "password",
+		digestParts: map[string]string{
+			"realm":     "testrealm@host.com",
+			"nonce":     "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+			"algorithm": "MD5-sess",
+			"qop":       "auth",
+		},
+	}
+	rq, _ := http.NewRequest("GET", "http://localhost/", nil)
+	if err := a.Authorize(nil, rq, "/dir/index.html"); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+
+	parts := parseDigestAuthorizationHeader(t, rq.Header.Get("Authorization"))
+	expectedHA1 := getMD5(fmt.Sprintf("%s:%s:%s",
+		getMD5("user:testrealm@host.com:password"),
+		"dcd98b7102dd2f0e8b11d0f600bfb0c093",
+		parts["cnonce"],
+	))
+	expectedHA2 := getMD5("GET:/dir/index.html")
+	expectedResponse := getMD5(fmt.Sprintf("%s:%s:%s:%s:%s:%s",
+		expectedHA1,
+		"dcd98b7102dd2f0e8b11d0f600bfb0c093",
+		parts["nc"],
+		parts["cnonce"],
+		"auth",
+		expectedHA2,
+	))
+
+	if parts["response"] != expectedResponse {
+		t.Fatalf("got response=%q, want %q", parts["response"], expectedResponse)
+	}
+	if parts["algorithm"] != "MD5-sess" {
+		t.Fatalf("got algorithm=%q, want MD5-sess", parts["algorithm"])
 	}
 }
 
@@ -72,4 +113,19 @@ func TestDigestAuthVerify(t *testing.T) {
 	if !redo {
 		t.Errorf("got redo: %t, want true", redo)
 	}
+}
+
+func parseDigestAuthorizationHeader(t *testing.T, header string) map[string]string {
+	t.Helper()
+
+	header = strings.TrimPrefix(header, "Digest ")
+	result := make(map[string]string)
+	for _, part := range strings.Split(header, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			t.Fatalf("malformed digest header part %q", part)
+		}
+		result[kv[0]] = strings.Trim(kv[1], `"`)
+	}
+	return result
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wxk6b1203/gowebdav
 
-go 1.17
+go 1.25

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/studio-b12/gowebdav
+module github.com/wxk6b1203/gowebdav
 
 go 1.17

--- a/netrc.go
+++ b/netrc.go
@@ -44,9 +44,35 @@ func ReadConfig(uri, netrc string) (string, string) {
 		return "", ""
 	}
 
+	defaultLogin, defaultPass := "", ""
 	tokens := strings.Fields(string(data))
 	for i := 0; i < len(tokens); {
 		if tokens[i] != "machine" {
+			if tokens[i] == "default" {
+				i++
+				login, pass := "", ""
+				for i < len(tokens) && tokens[i] != "machine" && tokens[i] != "default" {
+					switch tokens[i] {
+					case "login":
+						if i+1 < len(tokens) {
+							login = tokens[i+1]
+							i += 2
+							continue
+						}
+					case "password":
+						if i+1 < len(tokens) {
+							pass = tokens[i+1]
+							i += 2
+							continue
+						}
+					}
+					i++
+				}
+				if login != "" && pass != "" {
+					defaultLogin, defaultPass = login, pass
+				}
+				continue
+			}
 			i++
 			continue
 		}
@@ -58,7 +84,7 @@ func ReadConfig(uri, netrc string) (string, string) {
 		i += 2
 
 		login, pass := "", ""
-		for i < len(tokens) && tokens[i] != "machine" {
+		for i < len(tokens) && tokens[i] != "machine" && tokens[i] != "default" {
 			switch tokens[i] {
 			case "login":
 				if i+1 < len(tokens) {
@@ -81,5 +107,5 @@ func ReadConfig(uri, netrc string) (string, string) {
 		}
 	}
 
-	return "", ""
+	return defaultLogin, defaultPass
 }

--- a/netrc.go
+++ b/netrc.go
@@ -1,52 +1,83 @@
 package gowebdav
 
 import (
-	"bufio"
-	"fmt"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 )
 
 func parseLine(s string) (login, pass string) {
 	fields := strings.Fields(s)
-	for i, f := range fields {
-		if f == "login" {
+	for i := 0; i < len(fields); i++ {
+		switch fields[i] {
+		case "login":
+			if i+1 >= len(fields) {
+				return login, pass
+			}
 			login = fields[i+1]
-		}
-		if f == "password" {
+			i++
+		case "password":
+			if i+1 >= len(fields) {
+				return login, pass
+			}
 			pass = fields[i+1]
+			i++
 		}
 	}
 	return login, pass
+}
+
+func hostMatches(u *url.URL, machine string) bool {
+	return strings.EqualFold(machine, u.Host) || strings.EqualFold(machine, u.Hostname())
 }
 
 // ReadConfig reads login and password configuration from ~/.netrc
 // machine foo.com login username password 123456
 func ReadConfig(uri, netrc string) (string, string) {
 	u, err := url.Parse(uri)
+	if err != nil || u.Host == "" {
+		return "", ""
+	}
+
+	data, err := os.ReadFile(netrc)
 	if err != nil {
 		return "", ""
 	}
 
-	file, err := os.Open(netrc)
-	if err != nil {
-		return "", ""
-	}
-	defer file.Close()
-
-	re := fmt.Sprintf(`^.*machine %s.*$`, u.Host)
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		s := scanner.Text()
-
-		matched, err := regexp.MatchString(re, s)
-		if err != nil {
-			return "", ""
+	tokens := strings.Fields(string(data))
+	for i := 0; i < len(tokens); {
+		if tokens[i] != "machine" {
+			i++
+			continue
 		}
-		if matched {
-			return parseLine(s)
+		if i+1 >= len(tokens) {
+			break
+		}
+
+		machine := tokens[i+1]
+		i += 2
+
+		login, pass := "", ""
+		for i < len(tokens) && tokens[i] != "machine" {
+			switch tokens[i] {
+			case "login":
+				if i+1 < len(tokens) {
+					login = tokens[i+1]
+					i += 2
+					continue
+				}
+			case "password":
+				if i+1 < len(tokens) {
+					pass = tokens[i+1]
+					i += 2
+					continue
+				}
+			}
+			i++
+		}
+
+		if hostMatches(u, machine) && login != "" && pass != "" {
+			return login, pass
 		}
 	}
 

--- a/passportAuth.go
+++ b/passportAuth.go
@@ -103,7 +103,11 @@ func (p *PassportAuth) genCookies(c *http.Client, partnerUrl string, header *htt
 		Path:   "/login2.srf",
 	}
 
-	partnerServerChallenge := strings.Split(header.Get("Www-Authenticate"), " ")[1]
+	authHeaderParts := strings.SplitN(header.Get("Www-Authenticate"), " ", 2)
+	if len(authHeaderParts) != 2 {
+		return NewPathError("Authorize", "/", 401)
+	}
+	partnerServerChallenge := authHeaderParts[1]
 
 	req := http.Request{
 		Method: "GET",
@@ -164,17 +168,10 @@ func (p *PassportAuth) genCookies(c *http.Client, partnerUrl string, header *htt
 	}
 
 	// Step 8 (Set Token Message from Partner Server)
-	cookies := rs.Header.Values("Set-Cookie")
+	cookies := rs.Cookies()
 	p.cookies = make([]http.Cookie, len(cookies))
 	for i, cookie := range cookies {
-		cookieParts := strings.Split(cookie, ";")
-		cookieName := strings.Split(cookieParts[0], "=")[0]
-		cookieValue := strings.Split(cookieParts[0], "=")[1]
-
-		p.cookies[i] = http.Cookie{
-			Name:  cookieName,
-			Value: cookieValue,
-		}
+		p.cookies[i] = *cookie
 	}
 
 	return nil

--- a/passportAuth_test.go
+++ b/passportAuth_test.go
@@ -14,6 +14,7 @@ func TestNewPassportAuth(t *testing.T) {
 	pass := "password"
 	p1 := "some,comma,separated,values"
 	token := "from-PP='token'"
+	cookieValue := "YWJjPQ=="
 
 	authHandler := func(h http.Handler) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
@@ -38,12 +39,12 @@ func TestNewPassportAuth(t *testing.T) {
 				t.Error(err)
 			}
 			if reg.MatchString(r.Header.Get("Authorization")) {
-				w.Header().Set("Set-Cookie", "Pass=port")
+				w.Header().Set("Set-Cookie", "Pass="+cookieValue+"; Path=/")
 				h.ServeHTTP(w, r)
 				return
 			}
 			for _, c := range r.Cookies() {
-				if c.Name == "Pass" && c.Value == "port" {
+				if c.Name == "Pass" && c.Value == cookieValue {
 					h.ServeHTTP(w, r)
 					return
 				}

--- a/protocol_compat_test.go
+++ b/protocol_compat_test.go
@@ -1,0 +1,225 @@
+package gowebdav
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDigestPartsProtocolCompatibility(t *testing.T) {
+	rs := &http.Response{
+		Header: http.Header{
+			"Www-Authenticate": []string{`Digest realm="testrealm@host.com", qop="auth-int, auth", nonce="abc123", algorithm=md5-sess, opaque="xyz"`},
+		},
+	}
+
+	parts := digestParts(rs)
+	if parts["qop"] != "auth" {
+		t.Fatalf("got qop=%q, want auth", parts["qop"])
+	}
+	if parts["algorithm"] != "MD5-sess" {
+		t.Fatalf("got algorithm=%q, want MD5-sess", parts["algorithm"])
+	}
+	if parts["nonce"] != "abc123" {
+		t.Fatalf("got nonce=%q, want abc123", parts["nonce"])
+	}
+}
+
+func TestConnectDigestAuthProtocolCompatibility(t *testing.T) {
+	const (
+		realm  = "testrealm@host.com"
+		nonce  = "dcd98b7102dd2f0e8b11d0f600bfb0c093"
+		opaque = "5ccc069c403ebaf9f0171e9517f40e41"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if strings.HasPrefix(auth, "Digest ") {
+			parts := parseDigestAuthorizationHeader(t, auth)
+			expectedHA1 := getMD5(fmt.Sprintf("%s:%s:%s",
+				getMD5("digestUser:"+realm+":digestPW"),
+				nonce,
+				parts["cnonce"],
+			))
+			expectedHA2 := getMD5(r.Method + ":" + parts["uri"])
+			expectedResponse := getMD5(fmt.Sprintf("%s:%s:%s:%s:%s:%s",
+				expectedHA1,
+				nonce,
+				parts["nc"],
+				parts["cnonce"],
+				"auth",
+				expectedHA2,
+			))
+
+			if parts["qop"] == "auth" && parts["response"] == expectedResponse && parts["algorithm"] == "MD5-sess" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+		}
+
+		w.Header().Set("Www-Authenticate", `Digest realm="`+realm+`", qop="auth-int,auth", nonce="`+nonce+`", algorithm=md5-sess, opaque="`+opaque+`"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "digestUser", "digestPW")
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("connect with digest challenge variants: %v", err)
+	}
+}
+
+func TestProtocolConnectSendsOptionsDepthZero(t *testing.T) {
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "OPTIONS" {
+			t.Fatalf("got method=%s, want OPTIONS", r.Method)
+		}
+		if got := r.Header.Get("Depth"); got != "0" {
+			t.Fatalf("got Depth=%q, want 0", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+}
+
+func TestProtocolPropfindHeaders(t *testing.T) {
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			t.Fatalf("got method=%s, want PROPFIND", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/xml;charset=UTF-8" {
+			t.Fatalf("got Content-Type=%q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/xml,text/xml" {
+			t.Fatalf("got Accept=%q", got)
+		}
+
+		w.WriteHeader(207)
+		switch r.URL.Path {
+		case "/hello.txt":
+			if got := r.Header.Get("Depth"); got != "0" {
+				t.Fatalf("stat got Depth=%q, want 0", got)
+			}
+			_, _ = io.WriteString(w, `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/hello.txt</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:displayname>hello.txt</d:displayname>
+        <d:getcontentlength>15</d:getcontentlength>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+		case "/":
+			if got := r.Header.Get("Depth"); got != "1" {
+				t.Fatalf("readdir got Depth=%q, want 1", got)
+			}
+			_, _ = io.WriteString(w, `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:displayname>/</d:displayname>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/hello.txt</d:href>
+    <d:propstat>
+      <d:status>HTTP/1.1 200 OK</d:status>
+      <d:prop>
+        <d:displayname>hello.txt</d:displayname>
+        <d:getcontentlength>15</d:getcontentlength>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+	if _, err := cli.Stat("/hello.txt"); err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if _, err := cli.ReadDir("/"); err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+}
+
+func TestProtocolCopySendsDestinationAndOverwriteHeaders(t *testing.T) {
+	var (
+		gotDestination string
+		gotOverwrite   string
+	)
+
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "COPY" {
+			t.Fatalf("got method=%s, want COPY", r.Method)
+		}
+		gotDestination = r.Header.Get("Destination")
+		gotOverwrite = r.Header.Get("Overwrite")
+		w.WriteHeader(http.StatusCreated)
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+	if err := cli.Copy("/src file.txt", "/dst dir/file #1.txt", false); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	wantDestination := PathEscape(Join(FixSlash(srv.URL), "/dst dir/file #1.txt"))
+	if gotDestination != wantDestination {
+		t.Fatalf("got Destination=%q, want %q", gotDestination, wantDestination)
+	}
+	if gotOverwrite != "F" {
+		t.Fatalf("got Overwrite=%q, want F", gotOverwrite)
+	}
+}
+
+func TestProtocolReadStreamRangeSendsRangeHeader(t *testing.T) {
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Fatalf("got method=%s, want GET", r.Method)
+		}
+		if got := r.Header.Get("Range"); got != "bytes=4-7" {
+			t.Fatalf("got Range=%q, want bytes=4-7", got)
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.WriteString(w, "o go")
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+	stream, err := cli.ReadStreamRange("/hello.txt", 4, 4)
+	if err != nil {
+		t.Fatalf("range read: %v", err)
+	}
+	defer stream.Close()
+
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != "o go" {
+		t.Fatalf("got body=%q, want o go", string(body))
+	}
+}

--- a/regressions_test.go
+++ b/regressions_test.go
@@ -1,0 +1,125 @@
+package gowebdav
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}
+
+func TestParseLineMissingValue(t *testing.T) {
+	login, pass := parseLine("machine example.com login")
+	if login != "" || pass != "" {
+		t.Fatalf("got login=%q pass=%q, want both empty", login, pass)
+	}
+}
+
+func TestReadConfigMatchesHostnameWithoutPort(t *testing.T) {
+	dir := t.TempDir()
+	netrc := filepath.Join(dir, ".netrc")
+	content := "machine other.example login other password nope\n" +
+		"machine example.com\n" +
+		"  login demo\n" +
+		"  password secret\n"
+	if err := os.WriteFile(netrc, []byte(content), 0600); err != nil {
+		t.Fatalf("write netrc: %v", err)
+	}
+
+	login, pass := ReadConfig("https://example.com:8443/webdav", netrc)
+	if login != "demo" || pass != "secret" {
+		t.Fatalf("got login=%q pass=%q, want demo/secret", login, pass)
+	}
+}
+
+func TestStatInvalidXMLReturnsError(t *testing.T) {
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PROPFIND":
+			w.WriteHeader(207)
+			_, _ = io.WriteString(w, `<d:multistatus xmlns:d="DAV:"><d:response>`)
+		default:
+			w.WriteHeader(200)
+		}
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+	info, err := cli.Stat("/broken.txt")
+	if err == nil {
+		t.Fatalf("got info=%v, want xml parse error", info)
+	}
+
+	pe, ok := err.(*os.PathError)
+	if !ok {
+		t.Fatalf("got %T, want *os.PathError", err)
+	}
+	if pe.Op != "Stat" {
+		t.Fatalf("got op=%q, want Stat", pe.Op)
+	}
+}
+
+func TestReadStreamRangeFallbackWithoutServerRangeSupport(t *testing.T) {
+	content := []byte("hello gowebdav\n")
+	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(405)
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write(content)
+	})))
+	defer srv.Close()
+
+	cli := NewClient(srv.URL, "user", "password")
+
+	stream, err := cli.ReadStreamRange("/hello.txt", 4, 4)
+	if err != nil {
+		t.Fatalf("range read with length: %v", err)
+	}
+	defer stream.Close()
+
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("read limited range: %v", err)
+	}
+	if !bytes.Equal(got, []byte("o go")) {
+		t.Fatalf("got %q, want %q", got, "o go")
+	}
+
+	stream, err = cli.ReadStreamRange("/hello.txt", 6, 0)
+	if err != nil {
+		t.Fatalf("range read to end: %v", err)
+	}
+	defer stream.Close()
+
+	got, err = io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("read tail range: %v", err)
+	}
+	if !bytes.Equal(got, []byte("gowebdav\n")) {
+		t.Fatalf("got %q, want %q", got, "gowebdav\n")
+	}
+}
+
+func TestRemoveAllPreservesUnderlyingError(t *testing.T) {
+	cli := NewClient("https://example.com", "user", "password")
+	sentinel := errors.New("network down")
+	cli.SetTransport(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return nil, sentinel
+	}))
+
+	err := cli.RemoveAll("/hello.txt")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got %v, want wrapped %v", err, sentinel)
+	}
+}

--- a/regressions_test.go
+++ b/regressions_test.go
@@ -41,6 +41,36 @@ func TestReadConfigMatchesHostnameWithoutPort(t *testing.T) {
 	}
 }
 
+func TestReadConfigMachineEntryBeatsDefault(t *testing.T) {
+	dir := t.TempDir()
+	netrc := filepath.Join(dir, ".netrc")
+	content := "machine example.com login demo password secret\n" +
+		"default login guest password fallback\n"
+	if err := os.WriteFile(netrc, []byte(content), 0600); err != nil {
+		t.Fatalf("write netrc: %v", err)
+	}
+
+	login, pass := ReadConfig("https://example.com/webdav", netrc)
+	if login != "demo" || pass != "secret" {
+		t.Fatalf("got login=%q pass=%q, want demo/secret", login, pass)
+	}
+}
+
+func TestReadConfigFallsBackToDefault(t *testing.T) {
+	dir := t.TempDir()
+	netrc := filepath.Join(dir, ".netrc")
+	content := "machine example.com login demo password secret\n" +
+		"default login guest password fallback\n"
+	if err := os.WriteFile(netrc, []byte(content), 0600); err != nil {
+		t.Fatalf("write netrc: %v", err)
+	}
+
+	login, pass := ReadConfig("https://missing.example/webdav", netrc)
+	if login != "guest" || pass != "fallback" {
+		t.Fatalf("got login=%q pass=%q, want guest/fallback", login, pass)
+	}
+}
+
 func TestStatInvalidXMLReturnsError(t *testing.T) {
 	srv := httptest.NewServer(basicAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/utils.go
+++ b/utils.go
@@ -72,25 +72,33 @@ func parseModified(s *string) time.Time {
 
 func parseXML(data io.Reader, resp interface{}, parse func(resp interface{}) error) error {
 	decoder := xml.NewDecoder(data)
-	for t, _ := decoder.Token(); t != nil; t, _ = decoder.Token() {
+	for {
+		t, err := decoder.Token()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
 		switch se := t.(type) {
 		case xml.StartElement:
 			if se.Name.Local == "response" {
-				if e := decoder.DecodeElement(resp, &se); e == nil {
-					if err := parse(resp); err != nil {
-						return err
-					}
+				if err := decoder.DecodeElement(resp, &se); err != nil {
+					return err
+				}
+				if err := parse(resp); err != nil {
+					return err
 				}
 			}
 		}
 	}
-	return nil
 }
 
 // limitedReadCloser wraps a io.ReadCloser and limits the number of bytes that can be read from it.
 type limitedReadCloser struct {
 	rc        io.ReadCloser
-	remaining int
+	remaining int64
 }
 
 func (l *limitedReadCloser) Read(buf []byte) (int, error) {
@@ -98,12 +106,12 @@ func (l *limitedReadCloser) Read(buf []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	if len(buf) > l.remaining {
-		buf = buf[0:l.remaining]
+	if int64(len(buf)) > l.remaining {
+		buf = buf[0:int(l.remaining)]
 	}
 
 	n, err := l.rc.Read(buf)
-	l.remaining -= n
+	l.remaining -= int64(n)
 
 	return n, err
 }


### PR DESCRIPTION
This PR is generated by codex and review by codex and copilot. 

---

Original problems found by codex:

1. High risk: The XML parsing in PROPFIND silently ignores errors, causing callers to experience "false success." Files utils.go:73, client.go:183, client.go:116. parseXML ignores errors from decoder.Token() and DecodeElement(). As a result, when the server returns truncated or malformed XML, Stat might return nil, nil, and ReadDir might return incomplete results without signaling an error.
2. High risk: The downgrade logic in ReadStreamRange contradicts the comments; when length==0, it reads empty data directly. File client.go:355. When the server doesn't support Range and returns 200, the code wraps with limitedReadCloser{remaining:int(length)}; if length==0, it should "read from offset to the end" per the comment, but in reality, it immediately EOFs. The int(length) also poses a risk of overflow with large lengths.
3. High risk: The Digest MD5-sess algorithm is implemented incorrectly. File digestAuth.go:110. The HA1 for MD5-sess should use nonce, but here it mistakenly uses nonceCount. This causes authentication failure when connecting to servers requiring algorithm=MD5-sess.
4. Medium risk: RemoveAll incorrectly translates actual errors into a false 400 error. File client.go:241. If req("DELETE", ...) returns network, TLS, timeout, or authentication errors, it is uniformly converted to "Remove ...: 400", losing the real cause and preventing callers from identifying the actual problem.
5. Medium risk: The MS-PASS Cookie parsing is fragile and easily truncates valid tokens. File passportAuth.go:166. Set-Cookie is manually split by "=", and only the second part is taken. Since many cookie values contain = themselves, this approach truncates the values, causing subsequent requests to fail authentication.
6. Medium risk: The .netrc parsing has issues leading to crashes and matching errors. Files netrc.go:12, netrc.go:39. parseLine directly accesses fields[i+1], which can cause a panic when encountering an incomplete line. ReadConfig also directly incorporates u.Host into a regular expression, where . is treated as a wildcard, making host matches with ports prone to failure.
7. Medium-low risk: The CLI's PUT operation appends the full local path to the remote path when uploading to a remote directory. File cmd/gowebdav/main.go:198. If the target p0 is a remote directory and the local file is /tmp/a.txt, the result becomes something like /remoteDir//tmp/a.txt, whereas it should typically only append filepath.Base(p1).

---

This pull request introduces several improvements and fixes across authentication, error handling, file operations, and configuration parsing. The most significant changes are the refactoring and enhancement of Digest authentication logic, better error propagation, and improved `.netrc` parsing for credential loading. The update also adds new and more robust tests to ensure correct behavior.

**Authentication improvements:**

* Refactored Digest authentication parsing to more robustly handle `Www-Authenticate` headers, correctly parse directives, support multiple QOP and algorithm values, and ensure correct formatting of authorization headers (including nonce count and algorithm fields). Added helpers for parsing and normalization. [[1]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aL69-R164) [[2]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aL105-R184) [[3]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aL116-R197) [[4]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aL146-R225) [[5]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aL157-R236) [[6]](diffhunk://#diff-9ea382cf611e05caebcf5f75ee69af9e22bd325438f84578794051e11af1584aR247-R250)
* Improved Passport authentication by handling malformed headers gracefully and simplifying cookie extraction using `http.Response.Cookies()`. [[1]](diffhunk://#diff-9b4315fd51de1268c8c84763852f11da448f51e731a18b74a34020f4405e37edL106-R110) [[2]](diffhunk://#diff-9b4315fd51de1268c8c84763852f11da448f51e731a18b74a34020f4405e37edL167-R174)

**Error handling and file operations:**

* Improved error wrapping in `Client.Stat` and `Client.Remove` to use the correct operation name and propagate the original error instead of a generic status code. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL229-R229) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL244-R244)
* Fixed `Client.ReadStreamRange` to properly close response bodies on error, handle zero-length reads, and use the correct error type and operation name.

**Configuration and credential loading:**

* Refactored `.netrc` parsing to be more robust, supporting multi-line machine entries and case-insensitive host matching, and removed unnecessary dependencies.

**Command-line and test improvements:**

* Fixed `cmdPut` to use the local file's base name when uploading to a remote directory, ensuring correct remote paths.
* Added a comprehensive test for `cmdPut` to verify correct remote path usage.
* Enhanced Digest authentication tests, including a new test for the `MD5-sess` algorithm and helpers for parsing authorization headers. [[1]](diffhunk://#diff-f2513462294af858809fe041f53f0208561dc3d714b5ba34eaee8b78f25f4577R5) [[2]](diffhunk://#diff-f2513462294af858809fe041f53f0208561dc3d714b5ba34eaee8b78f25f4577L32-R78) [[3]](diffhunk://#diff-f2513462294af858809fe041f53f0208561dc3d714b5ba34eaee8b78f25f4577R117-R131)
* Updated Passport authentication tests to use a realistic cookie value and check for correct cookie handling. [[1]](diffhunk://#diff-021c8c56393582070ce6ac4aae8f43f36098fdda52b254e01435c48e2bff1255R17) [[2]](diffhunk://#diff-021c8c56393582070ce6ac4aae8f43f36098fdda52b254e01435c48e2bff1255L41-R47)